### PR TITLE
python-cicd-example to 0.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   version: 0.0.3
 - name: python-cicd-example
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.1
+  version: 0.0.3
 - name: python-jx-456
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.1


### PR DESCRIPTION
Promote python-cicd-example to version 0.0.3